### PR TITLE
Add pre-alpha action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: 🚀 Publish Docker
+
+on:
+  release:
+    types: [ published ]
+    workflow_dispatch:
+
+jobs:
+  publish:
+    name: 🚀 Publish Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛒 Checkout code
+        uses: actions/checkout@v4
+      - name: 🚀 Publish Docker
+        uses: elgohr/Publish-Docker-Github-Action@v5
+        with:
+          name: developmentanddinosaurs/github-actions-aws-cdk
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          default_branch: main
+          snapshot: true
+          tag_semver: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM amazoncorretto:21-al2023
+
+RUN yum update &&  \
+    yum -y install nodejs npm
+
+RUN npm install -g aws-cdk
+
+COPY --chmod=0755 entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,19 @@
+name: AWS CDK
+description: Run AWS CDK commands as a GitHub Action
+branding:
+  icon: cloud
+  color: orange
+inputs:
+  command:
+    description: CDK command to execute
+    required: true
+  stacks:
+    description: Stacks to execute the command against
+    required: true
+  working_directory:
+    description: Directory to execute CDK commands from
+    required: false
+    default: '.'
+runs:
+  using: docker
+  image: docker://developmentanddinosaurs/github-actions-aws-cdk:latest

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd "${INPUT_WORKING_DIRECTORY}" || exit
+echo "Working in $(pwd)"
+echo "${INPUT_COMMAND} \"${INPUT_STACKS}\""
+cdk "${INPUT_COMMAND} \"${INPUT_STACKS}\""


### PR DESCRIPTION
This adds everything required to publish the pre-alpha version of the action.

It probably doesn't do everything we need, and it might not even work, but it's a start.

This should accomplish the following:

- Dockerfile with everything required to run the CDK
- Script that can run CDK commands
- Workflow that publishes the Dockerfile to Docker Hub
- Action configuration that can be used to execute the Dockerfile

These should all work together fairly nicely to be able to run CDK commands from a GitHub workflow elsewhere, that will be able to run CDK commands for a JVM app, something that for some reason isn't very popular elsewhere.