### PR TITLE
Update tags to use just major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ credentials, and automatically makes them available for this action to use.
 
 ```yaml
 - name: ☁️ Deploy CDK
-  uses: development-and-dinosaurs/github-actions-aws-cdk@v1.0.5
+  uses: development-and-dinosaurs/github-actions-aws-cdk@v1
   with:
     command: deploy
     stacks: MyApplication
@@ -80,7 +80,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::123456789:role/my-cdk-deploy-role
       - name: ☁️ Deploy CDK
-        uses: development-and-dinosaurs/github-actions-aws-cdk@v1.0.5
+        uses: development-and-dinosaurs/github-actions-aws-cdk@v1
         with:
           command: deploy
           stacks: MyApplication

--- a/action.yaml
+++ b/action.yaml
@@ -16,4 +16,4 @@ inputs:
     default: '.'
 runs:
   using: docker
-  image: docker://developmentanddinosaurs/github-actions-aws-cdk:1.0.5
+  image: docker://developmentanddinosaurs/github-actions-aws-cdk:1


### PR DESCRIPTION
Will need to publish these tags again for it to work, but this will be better.